### PR TITLE
Feature/user authentication

### DIFF
--- a/src/main/java/com/example/competr/portal/controller/ProfileController.java
+++ b/src/main/java/com/example/competr/portal/controller/ProfileController.java
@@ -1,0 +1,32 @@
+package com.example.competr.portal.controller;
+
+import com.example.competr.portal.entity.Profile;
+import com.example.competr.portal.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/profiles")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @PostMapping
+    public ResponseEntity<Profile> createOrUpdateProfile(@RequestBody Profile profile) {
+        Profile savedProfile = profileService.createOrUpdateProfile(profile);
+        return ResponseEntity.ok(savedProfile);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<Profile> getProfileByUserId(@PathVariable long userId) {
+        Profile profile = profileService.getProfileByUserId(userId);
+        if (profile != null) {
+            return ResponseEntity.ok(profile);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}
+

--- a/src/main/java/com/example/competr/portal/controller/ProfileController.java
+++ b/src/main/java/com/example/competr/portal/controller/ProfileController.java
@@ -1,14 +1,17 @@
 package com.example.competr.portal.controller;
 
 import com.example.competr.portal.entity.Profile;
+import com.example.competr.portal.entity.User;
 import com.example.competr.portal.service.ProfileService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/profiles")
 @RequiredArgsConstructor
+@Slf4j
 public class ProfileController {
 
     private final ProfileService profileService;
@@ -18,15 +21,17 @@ public class ProfileController {
         Profile savedProfile = profileService.createOrUpdateProfile(profile);
         return ResponseEntity.ok(savedProfile);
     }
-
-    @GetMapping("/{userId}")
-    public ResponseEntity<Profile> getProfileByUserId(@PathVariable long userId) {
-        Profile profile = profileService.getProfileByUserId(userId);
+    @PostMapping("/userName")
+    public ResponseEntity<Profile> getProfileByUserName(@RequestBody User userName) {
+        log.info("Inside getProfileByUserName with userName: {}", userName.getUserName());
+        Profile profile = profileService.getProfileByUserName(userName.getUserName());
+        log.info("Profile found: {}", profile != null);
         if (profile != null) {
             return ResponseEntity.ok(profile);
         } else {
             return ResponseEntity.notFound().build();
         }
     }
+
 }
 

--- a/src/main/java/com/example/competr/portal/controller/UserController.java
+++ b/src/main/java/com/example/competr/portal/controller/UserController.java
@@ -3,6 +3,7 @@ package com.example.competr.portal.controller;
 import com.example.competr.portal.entity.User;
 import com.example.competr.portal.request.LoginRequest;
 import com.example.competr.portal.response.LoginResponse;
+import com.example.competr.portal.response.RegisterUserResponse;
 import com.example.competr.portal.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,15 +18,16 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/register")
-    public ResponseEntity<User> register(@RequestBody User user) {
+    public RegisterUserResponse register(@RequestBody User user) {
         log.info("Received registration request: phoneNumber={}, userName={}", user.getPhoneNumber(), user.getUserName());
+        RegisterUserResponse registerUserResponse = new RegisterUserResponse();
         try {
-            User savedUser = userService.registerUser(user);
-            log.info("Registration successful: userId={}, phoneNumber={}", savedUser.getId(), savedUser.getPhoneNumber());
-            return ResponseEntity.ok(savedUser);
+             registerUserResponse = userService.registerUser(user);
+            log.info("Registration successful: userName={}, phoneNumber={}",user.getUserName(), user.getPhoneNumber());
+            return registerUserResponse;
         } catch (Exception e) {
             log.error("Registration failed for phoneNumber={}: {}", user.getPhoneNumber(), e.getMessage());
-            return ResponseEntity.status(500).build();
+            return registerUserResponse;
         }
     }
 

--- a/src/main/java/com/example/competr/portal/controller/UserController.java
+++ b/src/main/java/com/example/competr/portal/controller/UserController.java
@@ -2,14 +2,12 @@ package com.example.competr.portal.controller;
 
 import com.example.competr.portal.entity.User;
 import com.example.competr.portal.request.LoginRequest;
+import com.example.competr.portal.response.LoginResponse;
 import com.example.competr.portal.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Optional;
-
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -32,17 +30,14 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<User> login(@RequestBody LoginRequest loginRequest) {
-        log.info("Received login request: phoneNumber={}", loginRequest.getPhoneNumber());
-        Optional<User> userOpt = userService.loginUser(loginRequest.getPhoneNumber(), loginRequest.getPassword());
-
-        if (userOpt.isPresent()) {
-            User user = userOpt.get();
-            log.info("Login successful: userId={}, phoneNumber={}", user.getId(), user.getPhoneNumber());
-            return ResponseEntity.ok(user);
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        LoginResponse loginResponse = userService.loginUser(loginRequest);
+        if (loginResponse.isStatus()) {
+            return ResponseEntity.ok(loginResponse);
         } else {
-            log.warn("Login failed: invalid credentials for phoneNumber={}", loginRequest.getPhoneNumber());
-            return ResponseEntity.status(401).build();
+            return ResponseEntity.status(401).body(loginResponse);
         }
     }
+
+
 }

--- a/src/main/java/com/example/competr/portal/entity/Profile.java
+++ b/src/main/java/com/example/competr/portal/entity/Profile.java
@@ -1,0 +1,20 @@
+package com.example.competr.portal.entity;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@NoArgsConstructor
+@Document(collection = "profiles")
+public class Profile {
+
+    @Id
+    private String id;
+    private long userId;
+    private String userName;
+    private int ranking;
+    private int points;
+}
+

--- a/src/main/java/com/example/competr/portal/filters/CustomUserDetailsService.java
+++ b/src/main/java/com/example/competr/portal/filters/CustomUserDetailsService.java
@@ -19,9 +19,9 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String phoneNumber) throws UsernameNotFoundException {
-        User user = userRepository.findByPhoneNumber(phoneNumber)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with phone number: " + phoneNumber));
+    public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
+        User user = userRepository.findByUserName(userName)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with userName: " + userName));
 
         // Assuming your user is always enabled and has USER role; adjust if you add more fields later
         return new org.springframework.security.core.userdetails.User(

--- a/src/main/java/com/example/competr/portal/filters/JwtAuthFilter.java
+++ b/src/main/java/com/example/competr/portal/filters/JwtAuthFilter.java
@@ -37,6 +37,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
+//        String path = request.getRequestURI();
+//        System.out.println(path);
+//
+//        if (path.equals("api/users/register") || path.equals("/api/users/login")  ) {
+//            chain.doFilter(request, response);
+//            return;
+//        }
         final String authHeader = request.getHeader("Authorization");
         System.out.println("[JwtAuthFilter] Request URI: " + request.getRequestURI());
         System.out.println("[JwtAuthFilter] Authorization header: " + (authHeader != null ? "Present" : "NULL"));

--- a/src/main/java/com/example/competr/portal/repository/ProfileRepository.java
+++ b/src/main/java/com/example/competr/portal/repository/ProfileRepository.java
@@ -1,0 +1,11 @@
+package com.example.competr.portal.repository;
+
+import com.example.competr.portal.entity.Profile;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProfileRepository extends MongoRepository<Profile, String> {
+    Profile findByUserId(long userId);
+}
+

--- a/src/main/java/com/example/competr/portal/repository/ProfileRepository.java
+++ b/src/main/java/com/example/competr/portal/repository/ProfileRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProfileRepository extends MongoRepository<Profile, String> {
-    Profile findByUserId(long userId);
+    Profile findByUserName(String userName);
 }
 

--- a/src/main/java/com/example/competr/portal/request/LoginRequest.java
+++ b/src/main/java/com/example/competr/portal/request/LoginRequest.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class LoginRequest {
-    private String phoneNumber;
+    private String mobile;
     private String password;
 }

--- a/src/main/java/com/example/competr/portal/response/RegisterUserResponse.java
+++ b/src/main/java/com/example/competr/portal/response/RegisterUserResponse.java
@@ -3,10 +3,7 @@ package com.example.competr.portal.response;
 import lombok.Data;
 
 @Data
-public class LoginResponse {
+public class RegisterUserResponse {
     private String errorMessage;
     private boolean status;
-    private String token;
-    private String userId;
-    private String userName;
 }

--- a/src/main/java/com/example/competr/portal/security/SecurityConfig.java
+++ b/src/main/java/com/example/competr/portal/security/SecurityConfig.java
@@ -26,7 +26,10 @@ public class SecurityConfig {
                                 .csrf(csrf -> csrf.disable())
                                 .cors(cors -> cors.disable())
                                 .authorizeHttpRequests(auth -> auth
+//                                                .requestMatchers("/api/users/register").permitAll()
                                                 .requestMatchers("/api/**").permitAll()
+                                                .requestMatchers("/api/users/login").permitAll()
+                                               // .requestMatchers("/api/**").authenticated()
                                                 .anyRequest().authenticated())
                                 .sessionManagement(session -> session
                                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/example/competr/portal/service/ProfileService.java
+++ b/src/main/java/com/example/competr/portal/service/ProfileService.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Service;
 @Service
 public interface ProfileService {
     public Profile createOrUpdateProfile(Profile profile);
-    public Profile getProfileByUserId(long userId);
+    public Profile getProfileByUserName(String userName);
 }

--- a/src/main/java/com/example/competr/portal/service/ProfileService.java
+++ b/src/main/java/com/example/competr/portal/service/ProfileService.java
@@ -1,0 +1,10 @@
+package com.example.competr.portal.service;
+
+import com.example.competr.portal.entity.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ProfileService {
+    public Profile createOrUpdateProfile(Profile profile);
+    public Profile getProfileByUserId(long userId);
+}

--- a/src/main/java/com/example/competr/portal/service/UserService.java
+++ b/src/main/java/com/example/competr/portal/service/UserService.java
@@ -1,6 +1,8 @@
 package com.example.competr.portal.service;
 
 import com.example.competr.portal.entity.User;
+import com.example.competr.portal.request.LoginRequest;
+import com.example.competr.portal.response.LoginResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -8,6 +10,6 @@ import java.util.Optional;
 @Service
 public interface UserService {
     public User registerUser(User user);
-    public Optional<User> loginUser(String phoneNumber, String password);
+    public LoginResponse loginUser(LoginRequest loginRequest);
 }
 

--- a/src/main/java/com/example/competr/portal/service/UserService.java
+++ b/src/main/java/com/example/competr/portal/service/UserService.java
@@ -3,13 +3,14 @@ package com.example.competr.portal.service;
 import com.example.competr.portal.entity.User;
 import com.example.competr.portal.request.LoginRequest;
 import com.example.competr.portal.response.LoginResponse;
+import com.example.competr.portal.response.RegisterUserResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Service
 public interface UserService {
-    public User registerUser(User user);
+    public RegisterUserResponse registerUser(User user);
     public LoginResponse loginUser(LoginRequest loginRequest);
 }
 

--- a/src/main/java/com/example/competr/portal/serviceImpl/ProfileServiceImpl.java
+++ b/src/main/java/com/example/competr/portal/serviceImpl/ProfileServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.competr.portal.serviceImpl;
+
+import com.example.competr.portal.entity.Profile;
+import com.example.competr.portal.repository.ProfileRepository;
+import com.example.competr.portal.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileServiceImpl implements ProfileService {
+
+    private final ProfileRepository profileRepository;
+
+    public Profile createOrUpdateProfile(Profile profile) {
+        Profile existingProfile = profileRepository.findByUserId(profile.getUserId());
+        if (existingProfile != null) {
+            existingProfile.setUserName(profile.getUserName());
+            existingProfile.setRanking(profile.getRanking());
+            existingProfile.setPoints(profile.getPoints());
+            return profileRepository.save(existingProfile);
+        }
+        return profileRepository.save(profile);
+    }
+
+    public Profile getProfileByUserId(long userId) {
+        return profileRepository.findByUserId(userId);
+    }
+}
+

--- a/src/main/java/com/example/competr/portal/serviceImpl/ProfileServiceImpl.java
+++ b/src/main/java/com/example/competr/portal/serviceImpl/ProfileServiceImpl.java
@@ -13,7 +13,7 @@ public class ProfileServiceImpl implements ProfileService {
     private final ProfileRepository profileRepository;
 
     public Profile createOrUpdateProfile(Profile profile) {
-        Profile existingProfile = profileRepository.findByUserId(profile.getUserId());
+        Profile existingProfile = profileRepository.findByUserName(profile.getUserName());
         if (existingProfile != null) {
             existingProfile.setUserName(profile.getUserName());
             existingProfile.setRanking(profile.getRanking());
@@ -23,8 +23,8 @@ public class ProfileServiceImpl implements ProfileService {
         return profileRepository.save(profile);
     }
 
-    public Profile getProfileByUserId(long userId) {
-        return profileRepository.findByUserId(userId);
+    public Profile getProfileByUserName(String userName){
+        return profileRepository.findByUserName(userName);
     }
 }
 

--- a/src/main/java/com/example/competr/portal/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/example/competr/portal/serviceImpl/UserServiceImpl.java
@@ -2,7 +2,10 @@ package com.example.competr.portal.serviceImpl;
 
 import com.example.competr.portal.entity.User;
 import com.example.competr.portal.repository.UserRepository;
+import com.example.competr.portal.request.LoginRequest;
+import com.example.competr.portal.response.LoginResponse;
 import com.example.competr.portal.service.UserService;
+import com.example.competr.portal.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -16,6 +19,7 @@ import java.util.Optional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
 
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
@@ -23,37 +27,57 @@ public class UserServiceImpl implements UserService {
     public User registerUser(User user) {
         log.info("Registering user with phoneNumber: {}", user.getPhoneNumber());
         try {
-            // Hash user password before saving
+            // Check if phone number already exists
+            Optional<User> existingUser = userRepository.findByPhoneNumber(user.getPhoneNumber());
+            if (existingUser.isPresent()) {
+                throw new IllegalArgumentException("User with this phone number already exists");
+            }
+
+            // Encode password and save new user
             user.setPassword(passwordEncoder.encode(user.getPassword()));
             User savedUser = userRepository.save(user);
             log.info("User registered successfully with id: {}", savedUser.getId());
             return savedUser;
         } catch (Exception e) {
-            log.error("Error during user registration for phoneNumber: {}, error: {}", user.getPhoneNumber(), e.getMessage());
-            throw e;  // Optionally re-throw to be handled upstream
+            log.error("User registration failed for phoneNumber: {}, error: {}", user.getPhoneNumber(), e.getMessage());
+            throw e;
         }
     }
 
+
     @Override
-    public Optional<User> loginUser(String phoneNumber, String password) {
-        log.info("Login request for phoneNumber: {}", phoneNumber);
+    public LoginResponse loginUser(LoginRequest loginRequest) {
+        String phoneNumber = loginRequest.getMobile();
+        log.info("Login attempt for phoneNumber: {}", phoneNumber);
+
         Optional<User> userOpt = userRepository.findByPhoneNumber(phoneNumber);
+        LoginResponse loginResponse = new LoginResponse();
 
         if (userOpt.isPresent()) {
             User user = userOpt.get();
-            boolean passwordMatches = passwordEncoder.matches(password, user.getPassword());
-            log.info("Password match for user {}: {}", phoneNumber, passwordMatches);
+            boolean matches = passwordEncoder.matches(loginRequest.getPassword(), user.getPassword());
+            log.info("Password match for phoneNumber {}: {}", phoneNumber, matches);
 
-            if (passwordMatches) {
-                log.info("Login successful for user with phoneNumber: {}", phoneNumber);
-                return Optional.of(user);
+            if (matches) {
+                String token = jwtUtil.generateToken(user.getUserName());
+                log.info("Login successful for userId: {}, phoneNumber: {}", user.getId(), phoneNumber);
+
+                loginResponse.setUserId(user.getId());
+                loginResponse.setStatus(true);
+                loginResponse.setToken(token);
+                return loginResponse;
             } else {
-                log.warn("Invalid password for user with phoneNumber: {}", phoneNumber);
+                log.warn("Invalid password for phoneNumber: {}", phoneNumber);
+                loginResponse.setUserId(user.getId());
+                loginResponse.setStatus(false);
+                loginResponse.setErrorMessage("Invalid phone number or password");
+                return loginResponse;
             }
         } else {
             log.warn("User not found with phoneNumber: {}", phoneNumber);
+            loginResponse.setStatus(false);
+            loginResponse.setErrorMessage("Invalid phone number or password");
+            return loginResponse;
         }
-
-        return Optional.empty();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=Competr_Portal
 server.port=8082
 
 #Db config
-spring.data.mongodb.uri=mongodb://localhost:27017/your_db_name
+spring.data.mongodb.uri=mongodb://localhost:27017/comptr
 # JWT Configuration
 jwt.secret=your-secret-key-here-make-it-long-and-secure-for-production
 jwt.access-token.expiration=7200


### PR DESCRIPTION
Pull Request: Support User Registration Without JWT and Profile Fetch via POST
Summary:
Updated Spring Security configuration to allow unauthenticated access only for POST /api/users/register and POST /api/users/login endpoints.
Enforced JWT authentication for all other /api/** endpoints.
Modified profile retrieval API from GET /api/profiles/{userName} to POST /api/profiles accepting userName in request body.
Implemented corresponding frontend change to fetch user profile via POST with JSON body.
Provided cURL example for the new profile API call with optional JWT authentication.
Added logging improvements for better tracing within the profile controller.
Details:
SecurityConfig:
Changed .requestMatchers to include HTTP method restrictions.
Ensured correct authorization rules with leading slashes in paths.
ProfileController:
Added POST endpoint to fetch profile by userName from request body.
General:
Improved error handling and logs during registration and profile fetch.
Confirmed JWT filter bypass for registration endpoint to allow token-less registration.